### PR TITLE
add skip_prepare and sleep_after_fail arg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.8)
 project(mysqlsct)
 
 include_directories(/usr/include/mysql/)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Usage: mysqlsct [OPTIONS]
 -m      --test-mode     test mode. now support sct and shortct
 -R      --port          mysql port for shortct mode
 -o      --host          mysql host for shortct mode
+-K      --skip-prepare skip data prepare.
+-f      --sleep-after_fail sleep ms after sct failed
 ```
 
 To test short connection mode, you should ensure that the query in 'short_connection_querys.txt' can be executed correctly in the database.

--- a/options.cc
+++ b/options.cc
@@ -41,6 +41,7 @@ uint detail_log = 0;
 uint64_t sleep_after_sct_failed = 1000; // s
 uint select_after_insert = 0;
 uint short_connection = 0;
+bool skip_prepare = 0;
 
 // test_mode contains "sct", "shortct"
 char *test_mode = nullptr;
@@ -56,6 +57,7 @@ static const struct option long_options[] = {
     {"detail-log", 1, nullptr, 'k'},       {"concurrency", 1, nullptr, 'c'},
     {"short-connection", 1, nullptr, 'S'}, {"test-mode", 1, nullptr, 'm'},
     {"port", 1, nullptr, 'R'}, {"host", 1, nullptr, 'o'},
+    {"skip-prepare", 1, nullptr, 'K'},     {"sleep-after-fail", 1, nullptr, 'f'},
 };
 
 
@@ -68,7 +70,7 @@ bool parse_option(int argc, char *argv[]) {
   }
 
   while (
-      (opt = getopt_long(argc, argv, "?vH:h:D:P:O:i:T:t:s:r:u:p:c:k:S:m:R:o:",
+      (opt = getopt_long(argc, argv, "?vH:h:D:P:O:i:T:t:s:r:u:p:c:k:S:m:R:o:K:f:",
                          long_options, nullptr)) != -1) {
     switch (opt) {
     case 'S':
@@ -150,6 +152,14 @@ bool parse_option(int argc, char *argv[]) {
       host = strdup(optarg);
       break;
 
+    case 'K':
+      skip_prepare = atoi(optarg) > 0 ? true : false;
+	  break;
+
+    case 'f':
+      sleep_after_sct_failed = atoi(optarg);
+	  break;
+
     default:
       cout << "parse argument failed" << endl;
       usage();
@@ -179,8 +189,10 @@ void usage() {
           "statistics with a specified interval in seconds.\n";
   cout << "-k	--detail-log	print detail error log.\n";
   cout << "-c	--concurrency	number of threads to use.\n";
-  cout << "-S --short-connection use short connection.\n";
-  cout << "-m --test-mode choose test mode";
+  cout << "-S	--short-connection use short connection.\n";
+  cout << "-m	--test-mode choose test mode.\n";
+  cout << "-K	--skip-prepare skip data prepare.\n";
+  cout << "-f	--sleep-after_fail sleep ms after sct failed";
 }
 
 bool verify_variables() {
@@ -206,6 +218,8 @@ bool verify_variables() {
   cout << "concurrency: " << concurrency << endl;
   cout << "short-connection: " << short_connection << endl;
   cout << "test-mode: " << test_mode << endl;
+  cout << "skip-prepasre: " << skip_prepare << endl;
+  cout << "sleep-after_fail" << sleep_after_sct_failed << endl;
   cout << "###########################################" << endl;
 
   if (strcmp(test_mode, "sct") == 0) {


### PR DESCRIPTION
1. 加入skip-prepare，避免每次重启脚本都重新插入数据
2. 在data prepare时打一条“thread xx data preparing"的log，当所有线程都在prepare的时候先不要输出qps的log
3. 加入sleep-after-fail参数